### PR TITLE
Adding a play_favorite function for players

### DIFF
--- a/pylmstools/player.py
+++ b/pylmstools/player.py
@@ -198,6 +198,22 @@ class LMSPlayer():
         except TypeError:
             pass
 
+    def play_favorite(self, name):
+        """
+        :type name: str, unicode
+        :param name: string to be found in favorite name, first favorite that matches a substring search will be selected.
+
+        Play a certain favorite on this player.
+        """
+        try:
+            favorites = self.parse_request("favorites items 0 100", "loop_loop")
+            fav_id = next(f for f in favorites if name in f["name"])["id"]
+            self.request("favorites playlist play item_id:{}".format(fav_id))
+        except TypeError:
+            pass
+        except StopIteration:
+            pass
+
     @property
     def name(self) -> str:
         """


### PR DESCRIPTION
Adding a function to the player object to select a favorite to play by name. The first favorite to match by substring is selected, if no favorite is found, the player is not instructed to do anything.

Example:

```python
server = LMSServer("192.168.1.2")
player = server.get_players()[0]
player.play_favorite("TSF Jazz")
```

